### PR TITLE
Transformertest

### DIFF
--- a/lib/ast_transformer.ml
+++ b/lib/ast_transformer.ml
@@ -1,23 +1,34 @@
-(* open Ast
+open Ast
 
-(* :grid transformer: skal ikke printe nodes men lave GridAndObjects om til NormalObjects *)
-let expand_grid rows cols extra =
-  let nodes =
-    List.init rows (fun r ->
-      List.init cols (fun c -> Printf.sprintf "node%d-%d" r c)
-    )
-    |> List.flatten
-  in
-  nodes @ extra
+let grid_to_strings rows cols =
+  let acc = ref [] in
+    for i = 0 to rows - 1 do
+      for j = 0 to cols -1 do
+        acc := Printf.sprintf "node%d-%d" i j :: !acc
+      done
+    done;
+  (* List is built in reverse so it must be reversed *)
+  List.rev !acc
+
+let transform_objects_decl obj =
+  match obj with
+  | NormalObjects _ -> obj
+  | GridAndObjects (rows, cols, objs) ->
+    let grid_objs = grid_to_strings rows cols in
+        NormalObjects (grid_objs @ objs)
+   
+
+(*
+let transform_argument arg =
+  assert false
+*)
 
 
 
-  (* locked_nodes transformer *)
-  let locked_nodes_transformer rows state = 
-    assert false
-
-  *)
-
+(*
+let transform_state state =
+  assert false
+*)
 
 
   (* i main: i main: 

--- a/lib/ast_transformer.ml
+++ b/lib/ast_transformer.ml
@@ -12,7 +12,9 @@ let grid_to_strings rows cols =
 
 let transform_objects_decl obj =
   match obj with
+  (* If NormalObjects do nothing *)
   | NormalObjects _ -> obj
+  (* If GridAndObjects transform into NormalObjects *)
   | GridAndObjects (rows, cols, objs) ->
     let grid_objs = grid_to_strings rows cols in
         NormalObjects (grid_objs @ objs)


### PR DESCRIPTION
I ast_transformer:
transform_objects_decl transformerer GridAndObjects til NormalObjects. Hvis parameteren matches med NormalObjects gør den ingenting

grid_to_strings er bare en hjælpefunktion


For kontekst:
:grid 6 6 key1 key2... (GridAndObjects)
node1-1 node1-2 ... key1 key2 (NormalObjects)