### PR TITLE
tjek at rows og cols er positive

### DIFF
--- a/lib/ast_validator.ml
+++ b/lib/ast_validator.ml
@@ -11,12 +11,20 @@ let row_count rows =
   0
   rows
 
-    (* Count how many collums a matrix has*)
+(* Count how many collums a matrix has*)
 let cols_count row =
   let expanded_row = Utils.expand_row row in
   List.fold_left (fun acc _ -> acc + 1) 0 expanded_row
 
-  (* Validate if a shape key has already been assigned to another shape*)
+let has_name name =
+  if name = "" then
+    failwith "Grid must have a name"
+
+let positive_rows_cols rows cols =
+  if rows <= 0 || cols <= 0 then
+    failwith "Rows and columns must be positive"
+
+(* Validate if a shape key has already been assigned to another shape*)
 let validate_unique_shapes shapes =
   let seen = Hashtbl.create 16 in
   List.iter
@@ -138,6 +146,8 @@ let validate_grid grid =
  | Some expected_rows, Some expected_cols, Some expected_name ->
       validate_unique_shapes grid.shapes;
       validate_unique_keys grid.key_names;
+      positive_rows_cols expected_rows expected_cols;
+      has_name expected_name;
       (match grid.locked with
  | None -> ()
 

--- a/lib/ast_validator.ml
+++ b/lib/ast_validator.ml
@@ -16,10 +16,6 @@ let cols_count row =
   let expanded_row = Utils.expand_row row in
   List.fold_left (fun acc _ -> acc + 1) 0 expanded_row
 
-let has_name name =
-  if name = "" then
-    failwith "Grid must have a name"
-
 let positive_rows_cols rows cols =
   if rows <= 0 || cols <= 0 then
     failwith "Rows and columns must be positive"
@@ -147,7 +143,6 @@ let validate_grid grid =
       validate_unique_shapes grid.shapes;
       validate_unique_keys grid.key_names;
       positive_rows_cols expected_rows expected_cols;
-      has_name expected_name;
       (match grid.locked with
  | None -> ()
 


### PR DESCRIPTION
tjek at rows og cols er positive. har også tilføjet funktion der tjekker at name ikke er en tom streng men den bliver aldrig brugt fordi parseren kun kan parse hvis grid har et navn. der kunne man lave en parsertest