### PR TITLE
Refactoring lexer and parser

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,7 +1,7 @@
 
 let () =
   Compiler.process_file "./data/domain.pddl";
-  Compiler.process_file "./data/problem_gridindefine.pddl";
+  Compiler.process_file "./data/arrayconstructs.pddl";
 
   Planner.check_planner_installed ();
   Planner.run_planner ()

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,7 +1,7 @@
 
 let () =
   Compiler.process_file "./data/domain.pddl";
-  Compiler.process_file "./data/arrayconstructs.pddl";
+  Compiler.process_file "./data/problem_gridindefine.pddl";
 
   Planner.check_planner_installed ();
   Planner.run_planner ()

--- a/data/arrayconstructs.pddl
+++ b/data/arrayconstructs.pddl
@@ -11,10 +11,9 @@
       :keys key0 key1 key2 
       :shapes ((T = triangle) (D = diamond))
 
-      ; Nu fungere det sådan at det man definere i griddet under :shapes er det man kan bruge, så hvis man skriver shape square i
-      ; lockednodesarray så får man en parser fejl, fordi :shapes i grid er vores verden, så det er kun dem man kan bruge i sit grid.
+      ; The :shapes in the grid section is what you can use in the lockednodesarray
+      ; This array structure parses locked and open nodes
 
-      ; Nu når man skriver den her array konstruktør, så parser den locked nodes og open nodes, dem som man ikke skriver i arrayet.
       :lockednodesarray fileno ([(3,2) (3,3) (3,4) (4,2) (4,3) (4,4) (5,2) (5,3)] (shape diamond))
 
       :keylocations fileno ([
@@ -32,7 +31,7 @@
    (:init (arm-empty)
          
         ;;virker ikke uden denne og goal
-        (at-robot node5-5))
+        (at-robot fileno5-5))
           
-   (:goal (at key8 node3-2))
+   (:goal (at key2 fileno3-2))
 )

--- a/data/problem_grid.pddl
+++ b/data/problem_grid.pddl
@@ -8,8 +8,8 @@
       :columns 2
       :name fileno
       :connections -H
-      :keys key0 key1
-      :shapes ((St = star))
+      :keys key1
+      :shapes ((D = diamond))
       
    )
 
@@ -33,7 +33,7 @@
 
    (:init (arm-empty)
          
-        (at-robot fileno1-0))
+        (at-robot grid20-1))
           
-   (:goal (at key1 fileno1-1))
+   (:goal (at key0 grid20-5))
 )

--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -52,8 +52,7 @@ type row =
 
 
 type argument = 
-| OnlyArguments of {a : string}
-| GridArguments of int * int 
+| OnlyArguments of {a : string} 
 | OpenNodesArgs of node list
 
 type state = 
@@ -68,9 +67,6 @@ type init = state list
 
 type goal = expr
 
-(* type stmt = {
-  name : string list;
-} *)
 
 type grid_param =
   | GP_rows of int

--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -26,13 +26,7 @@ rule token = parse
   | ":objects" {OBJECTS}
   | ":init" {INIT}
   | ":goal" {GOAL}
-  (*| "locked_nodes_matrix" {LOCKEDNOTESMATRIX} (**)
-  | "locked_nodes" {LOCKEDNODES} (**)
-  | "grid_connection" {GRIDCONNECTION} (**)
-  | "open_nodes" {OPENNODES} (**)
-  | "keylocation_matrix" {KEYLOCATIONMATRIX} (**)
   (*Grid Part Problem File*)
-  | ":grid" {GRID}*)
   | "("  { lparen_or_grid lexbuf }
   | ":rows" {ROWS}
   | ":columns" {COLUMNS}
@@ -53,11 +47,9 @@ rule token = parse
   | "]" {RBRACKET}
   | "," {COMMA}
   | "=" {EQUALS}
-  (*| "-" {DASH}*)
   | "+" {PLUS}
   | "*" {MULT}
   | integer as c { CONST (int_of_string c) }
-  (*| ['a'-'z' 'A'-'Z' '0'-'9' '-'] as id {CHARACTER id}  Giver alt for mange problemer med andre typer som bliver lavet om til character token og omvendt*)
   | ['a'-'z' 'A'-'Z'] ['a'-'z' 'A'-'Z' '0'-'9' '_' '-']* as id { NAME id }  
   | '?' ['a'-'z' 'A'-'Z'] ['a'-'z' 'A'-'Z' '0'-'9' '_' '-']* as id { VAR id } (* Because all variables start with '?' *)
   | '-' ['a'-'z' 'A'-'Z'] as id {FLAG id}

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -239,7 +239,6 @@ flag:
 | f = FLAG { f }
 ;
 
-
 (* supports use of classic matrix notation OR mult-notation but not both simultaneousely *)
 grid_rows:
 | { [] }

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -29,7 +29,7 @@
 (* grammar rules *)
 (* the program starts by evaluating define *)
 prog:
-| defs = define EOF (*men det program start it reads the define block in the domain file, and when its done with it, it is done=EOF*)
+| defs = define EOF (* The program starts by parsing <prog> then it parses the define block, and when its done with it, it is done=EOF*)
 { {defs = defs} } (*record, is used for ast. The purple bracket is a node/ocaml record for our ast*)
 ;
 
@@ -51,7 +51,7 @@ declaration_list:
 
 
 domain:
-| LPAREN DOMAIN name = NAME RPAREN { { domain_name = name } } (*reasds domain part of domain file, and adds node to ast*)
+| LPAREN DOMAIN name = NAME RPAREN { { domain_name = name } } (*reads domain part of domain file, and adds node to ast*)
 
 
 (*  below, params gets defined as a list *)
@@ -145,8 +145,6 @@ problemdomain:
 
 objects:
 | LPAREN OBJECTS ob = ob_list RPAREN { NormalObjects ob }
-(*| LPAREN OBJECTS LPAREN GRID rows = CONST columns = CONST grid_name = NAME RPAREN ob = ob_list RPAREN { GridAndObjects (rows, columns, grid_name, ob) }
-| LPAREN OBJECTS ob = ob_list LPAREN GRID rows = CONST columns = CONST grid_name = NAME RPAREN RPAREN { GridAndObjects (rows, columns, grid_name, ob) }*)
 ;
 
 gridlist:
@@ -218,25 +216,8 @@ arg_list:
 
 argument:
 | a = NAME { OnlyArguments { a } }
-(*| GRID i1 = CONST i2 = CONST { GridArguments ( i1, i2 ) }*)
 | LBRACKET n = node_list RBRACKET { OpenNodesArgs ( n ) }
 ;
-
-
-
-(*SKAL NOK BRUGES SENERE MEN GIVER WARNING NU, ALLE 5 locked_nodes til node*)
-
-(*locked_nodes:
-| LPAREN LOCKEDNODES LBRACKET n = node_list RBRACKET s = state RPAREN { LockedNodes ( n, s ) }
-;*)
-
-(*open_nodes:
-| LPAREN OPENNODES LPAREN rc = rc_list RPAREN s = state RPAREN { OpenNodes ( rc, s ) }
-;
-
-rc_list:
-| rows = NAME r1 = CONST DASH r2 = CONST cols = NAME c1 = CONST DASH c2 = CONST { RowsColumns ( rows, r1, r2, cols, c1, c2 ) }
-;*)
 
 
 node_list:
@@ -248,13 +229,6 @@ node:
 | LPAREN i1 = CONST COMMA i2 = CONST RPAREN { Node ( i1, i2 ) }
 ;
 
-(*locked_nodes_matrix:
-| LPAREN LOCKEDNODESMATRIX LBRACKET r = rows RBRACKET s = state RPAREN { LockedNodesMatrix { rows = r; shape = s } }
-;*)
-
-(*gridconnection:
-| LPAREN GRIDCONNECTION fl = flag_list RPAREN { GridConnection fl }
-;*)
 
 flag_list:
 | { [] }
@@ -265,9 +239,6 @@ flag:
 | f = FLAG { f }
 ;
 
-(*keylocation_matrix:
-| LPAREN KEYLOCATIONMATRIX LBRACKET r = rows RBRACKET RPAREN { KeylocationMatrix { rows = r } }
-;*)
 
 (* supports use of classic matrix notation OR mult-notation but not both simultaneousely *)
 grid_rows:


### PR DESCRIPTION
Slettet udkommenterede kode, og har slettet GridArguments fra ast filen i type argument. Har testet alle filerne i data mappen pddl filer undtagen domain-mini.pddl, som nok måske bare skal slettes. Skulle også ændre nogle ting inde i problem_grid.pddl før den gad og virke med planneren. I må gerne lige teste det selv også, og se om det også køre på jeres computer. 

I bund og grund har jeg som sagt bare slettet udkommenterede kode i lexeren og i parsen, og slettet GridArguments i ast filen. Dog tror jeg også vi kan slette mere i ast filen, og refactor den ydeligere, men måske det også kræver at vi refactore nogle af vores trasnformer funktioner, så det er nok ikke nogen god ide, da det virker kompliceret.